### PR TITLE
Added lazy loading for event images in EventTimeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4059,16 +4059,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/html-element-attributes": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/html-element-attributes/-/html-element-attributes-2.3.0.tgz",
-      "integrity": "sha512-RJv2v3BBaYSc0ODHwT0sqWI+2lFs6DATBvCRnW20BDmULxoAWvfT6r28uL8LcW1a9/eqUl+1DccUOJzw00qVXQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -4634,16 +4624,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-whitespace-character": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
-      "integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -4979,33 +4959,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/md-attr-parser": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/md-attr-parser/-/md-attr-parser-1.3.0.tgz",
-      "integrity": "sha512-KTVlfU5Oxo/6kd0YZ2mLP3eWJj+5vzh5mBCxLo3yGl1fzHIgxmtadbE9tHb7TbUBi3XZbl+P0xKeGmakat135w==",
-      "license": "MIT"
-    },
-    "node_modules/mdast-util-directive": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-3.1.0.tgz",
-      "integrity": "sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "@types/unist": "^3.0.0",
-        "ccount": "^2.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0",
-        "parse-entities": "^4.0.0",
-        "stringify-entities": "^4.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdast-util-find-and-replace": {
@@ -5392,25 +5345,6 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-extension-directive": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
-      "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-factory-whitespace": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0",
-        "parse-entities": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-gfm": {
@@ -7073,16 +7007,6 @@
         "hast-util-raw": "^9.0.0",
         "vfile": "^6.0.0"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-footnotes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/remark-footnotes/-/remark-footnotes-1.0.0.tgz",
-      "integrity": "sha512-X9Ncj4cj3/CIvLI2Z9IobHtVi8FVdUrdJkCNaL9kdX8ohfsi18DXHsCVd/A7ssARBdccdDb5ODnt62WuEWaM/g==",
-      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"

--- a/src/components/features/EventTimeline.tsx
+++ b/src/components/features/EventTimeline.tsx
@@ -18,7 +18,7 @@ import {
 import { Event } from "@/types/event";
 import Image from "next/image";
 import { useImagePreview } from "@/context/ImagePreviewContext";
-import { withUploadPath } from "../common/HelperFunction"
+import { withUploadPath } from "../common/HelperFunction";
 
 interface EventTimelineProps {
   events: Event[];
@@ -161,10 +161,13 @@ const EventTimelineItem: React.FC<{ event: Event; index: number }> = ({
                 alt={event.title}
                 unoptimized
                 fill
+                loading="lazy"
+                priority={index < 3} // this will load first 3 images immediately
                 sizes="(max-width: 640px) 100vw, (max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw"
                 className="transition-transform duration-300 hover:scale-105 cursor-pointer object-cover"
                 onClick={() =>
-                  event.image && openPreview(withUploadPath(event.image), event.title)
+                  event.image &&
+                  openPreview(withUploadPath(event.image), event.title)
                 }
               />
             </div>
@@ -231,14 +234,16 @@ const EventTimelineItem: React.FC<{ event: Event; index: number }> = ({
                   </span>
                 </div>
               )}
-              {(event.participants && event.participants>0)? (
+              {event.participants && event.participants > 0 ? (
                 <div className="flex items-start gap-2 text-[#e0e0e0]">
                   <Users size={16} className="mt-0.5 flex-shrink-0" />
                   <span className="font-medium">
                     {event.participants} participants
                   </span>
                 </div>
-              ) : ""}
+              ) : (
+                ""
+              )}
 
               {event.organizer && (
                 <div className="text-xs text-[#e0e0e0] mt-3 border-t-2 border-white pt-2">


### PR DESCRIPTION

This pull request adds **lazy loading** support for event images in the `EventTimeline` component.

### What’s Changed
- Added `loading="lazy"` attribute to the `<Image />` component to delay loading until images enter the viewport.
- Added `priority={index < 3}` to preload the first three images for smoother user experience.
- Minor formatting cleanup and consistency improvements.

### Why This Change
Previously, all event images were being loaded at once, which affected page load speed and performance on the `/events` page.  
Lazy loading ensures:
- Faster initial page rendering.
- Lower data usage for users.
- Smoother scrolling performance.

### How It Was Tested
- Ran `npm run dev` locally.
- Verified images on `/events` page load **only when scrolled into view**.
- Confirmed that the first three images load immediately for better visual experience.
- No console errors or broken styles after implementation.

###  Files Changed
- `src/components/features/EventTimeline.tsx`
- `package-lock.json` (auto-generated, no manual edits)

---

**Closes:** #17  
