### PR TITLE
Fix #16: Update Makefile for pm2 deployment and server-side execution

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 # Astronautics Club Website Makefile
-# This Makefile provides commands for Docker management, development, and maintenance tasks.
-# For Bare-Metal NGINX Deployment (No Docker)
+# This Makefile provides commands for development, production deployment, and maintenance.
+# Designed to run on the production server with pm2 process management.
 
 SERVER_PATH=/var/data/astronautics
 BACKUP_PATH=/var/data/astronautics-backup
@@ -9,144 +9,158 @@ BLOG_IMAGES_UPLOAD_PATH=$(SERVER_PATH)/blogs
 GALLERY_UPLOAD_PATH=$(SERVER_PATH)/gallery
 LOGS_PATH=$(SERVER_PATH)/logs
 LOCAL_BACKUP_DIR=./backups
+PM2_APP_NAME=astronautics
 
-.PHONY: help build deploy start stop restart status \
+.PHONY: help dev build deploy start stop restart status logs \
         backup-uploads restore-uploads backup-logs restore-logs \
-        clean-backups clean-downloads init-project rebuild
+        clean-backups init-backup rebuild
 
 help:
 	@echo "Astronautics Club Website Makefile"
 	@echo ""
-	@echo "Core Commands:"
-	@echo "  make build                 - Build development files (Next.js build)"
-	@echo "  make build-production      - Build for production"
-	@echo "  make deploy                - Deploy build to server"
-	@echo "  make restart               - Restart pm2, NGINX service"
-	@echo "  make status                - Check pm2, NGINX service status"
+	@echo "Development:"
+	@echo "  make dev                   - Start development server"
+	@echo "  make build                 - Build for production"
 	@echo ""
-	@echo "Backup & Restore:"
-	@echo "  make backup-uploads                               - Backup uploads from server"
-	@echo "  make restore-uploads FILE=path/to/zip  - Restore uploads to server"
-	@echo "  make backup-logs                                     - Backup logs from server"
-	@echo "  make restore-logs FILE=path/to/zip         - Restore logs to server"
+	@echo "Production Deployment (run on server):"
+	@echo "  make deploy                - Build and deploy with pm2"
+	@echo "  make start                 - Start pm2 application"
+	@echo "  make stop                  - Stop pm2 application"
+	@echo "  make restart               - Restart pm2 application"
+	@echo "  make status                - Check pm2 status"
+	@echo "  make logs                  - View pm2 logs"
+	@echo ""
+	@echo "Backup & Restore (run on server):"
+	@echo "  make backup-uploads        - Backup uploads directory"
+	@echo "  make restore-uploads FILE=path/to/zip - Restore uploads"
+	@echo "  make backup-logs           - Backup logs directory"
+	@echo "  make restore-logs FILE=path/to/zip    - Restore logs"
 	@echo ""
 	@echo "Maintenance:"
 	@echo "  make clean-backups         - Delete local backup files"
-	@echo "  make init-backup          - Setup local folders for backup"
-	@echo "  make rebuild               - Clean and redeploy from scratch"
+	@echo "  make init-backup           - Create backup directories"
+	@echo "  make rebuild               - Clean rebuild and deploy"
 
 
-# === BUILD ===
-build:
-	@echo "Building frontend for development..."
-# 	@if [ ! -f ".env.local" ]; then \
-# 		cp .env.example .env.local \
-# 	fi
+# === DEVELOPMENT ===
+dev:
+	@echo "Starting development server..."
+	@if [ ! -f ".env.local" ]; then \
+		echo "Warning: .env.local not found. Copy from .env.example if needed."; \
+	fi
 	npm install
 	npx tsx scripts/create-db-tables.ts
 	npm run dev
-	@echo "Build completed."
 
-build-production:
-	@echo "Building frontend for production..."
-# 	@if [ ! -f ".env.local" ]; then \
-# 		cp .env.example .env.local \
-# 	fi
+# === BUILD ===
+build:
+	@echo "Building for production..."
+	@if [ ! -f ".env.local" ]; then \
+		echo "Warning: .env.local not found. Copy from .env.example if needed."; \
+	fi
 	npm install --omit=dev
-	@npx tsx scripts/create-db-tables.ts
+	npx tsx scripts/create-db-tables.ts
 	npm run build
 	@echo "Production build completed."
 
 # === DEPLOYMENT ===
 deploy:
-	@echo "Building the project"
-	make build-production
-#	if	pm2 --version
-#	npm install pm2 -g
-#	fi
-	@echo "Deploying via pm2"
-	pm2 restart astronautics || pm2 start ecosystem.config.js
+	@echo "Deploying application with pm2..."
+	@$(MAKE) build
+	@echo "Starting/restarting pm2 process..."
+	@if ! command -v pm2 > /dev/null; then \
+		echo "Error: pm2 not found. Install with: npm install -g pm2"; \
+		exit 1; \
+	fi
+	pm2 restart $(PM2_APP_NAME) || pm2 start ecosystem.config.js --name $(PM2_APP_NAME)
 	pm2 save
-	@echo "Deployment completed"
+	@echo "Deployment completed successfully."
+
 
 # === SERVICE MANAGEMENT ===
 start:
-	@echo "Starting NGINX, pm2"
-	sudo systemctl start nginx
-	pm2 restart astronautics || pm2 start ecosystem.config.js
+	@echo "Starting pm2 application..."
+	@if ! command -v pm2 > /dev/null; then \
+		echo "Error: pm2 not found. Install with: npm install -g pm2"; \
+		exit 1; \
+	fi
+	pm2 start ecosystem.config.js --name $(PM2_APP_NAME) || pm2 restart $(PM2_APP_NAME)
 	pm2 save
-	@echo "Started NGINX, pm2 successfully"
+	@echo "Application started successfully."
 
 stop:
-	@echo "Stopping NGINX, pm2"
-	sudo systemctl stop nginx
-	pm2 stop astronautics
-	@echo "Stopped NGINX, pm2"
-
-restart: stop start
-
-logs:
-	@echo "Showing logs from NGINX, pm2"
-	cat /var/log/nginx/access.log
-	cat /var/log/nginx/error.log
-	pm2 logs astronautics
+	@echo "Stopping pm2 application..."
+	pm2 stop $(PM2_APP_NAME)
+	@echo "Application stopped."
 
 restart:
-	@echo "Restarting NGINX, pm2"
-	ssh $(SERVER_USER)@$(SERVER_HOST) 'sudo systemctl restart nginx'
-	pm2 restart astronautics
+	@echo "Restarting pm2 application..."
+	pm2 restart $(PM2_APP_NAME)
+	@echo "Application restarted successfully."
 
 status:
-	@echo "pm2, NGINX status"
-	pm2 status astronautics
+	@echo "Checking pm2 status..."
+	pm2 status $(PM2_APP_NAME)
+
+logs:
+	@echo "Showing pm2 logs (Ctrl+C to exit)..."
+	pm2 logs $(PM2_APP_NAME)
+
 
 # === BACKUPS ===
 backup-uploads:
-	@echo "Backing up uploads from server..."
-	mkdir -p $(LOCAL_BACKUP_DIR)
-	ssh $(SERVER_USER)@$(SERVER_HOST) "cd $(UPLOADS_PATH) && zip -r /tmp/uploads_backup.zip ."
-	@echo "Uploads backed up successfully."
+	@echo "Backing up uploads..."
+	@mkdir -p $(LOCAL_BACKUP_DIR)
+	@cd $(SERVER_PATH) && tar -czf $(LOCAL_BACKUP_DIR)/uploads_$$(date +%Y%m%d_%H%M%S).tar.gz \
+		avatars blogs gallery 2>/dev/null || echo "Some upload directories may not exist"
+	@echo "Uploads backed up successfully to $(LOCAL_BACKUP_DIR)"
 
 restore-uploads:
 	@if [ -z "$(FILE)" ]; then \
 		echo "Error: FILE parameter is required."; \
-		echo "Usage: make restore-uploads FILE=path/to/backup.zip"; \
+		echo "Usage: make restore-uploads FILE=path/to/backup.tar.gz"; \
 		exit 1; \
 	fi
-	@echo "Restoring uploads to server..."
-	scp "$(FILE)" $(SERVER_USER)@$(SERVER_HOST):/tmp/uploads_restore.zip
-	ssh $(SERVER_USER)@$(SERVER_HOST) "sudo unzip -o /tmp/uploads_restore.zip -d $(UPLOADS_PATH) && rm /tmp/uploads_restore.zip"
+	@echo "Restoring uploads from $(FILE)..."
+	@tar -xzf "$(FILE)" -C $(SERVER_PATH)
 	@echo "Uploads restored successfully."
 
 backup-logs:
-	ssh $(SERVER_USER)@$(SERVER_HOST) "cd $(LOGS_PATH) && zip -r /tmp/logs_backup.zip ."
-	scp $(SERVER_USER)@$(SERVER_HOST):/tmp/logs_backup.zip $(LOCAL_BACKUP_DIR)/logs_$$(date +%Y%m%d_%H%M%S).zip
-	ssh $(SERVER_USER)@$(SERVER_HOST) "rm /tmp/logs_backup.zip"
-	@echo "Logs backed up successfully."
+	@echo "Backing up logs..."
+	@mkdir -p $(LOCAL_BACKUP_DIR)
+	@if [ -d "$(LOGS_PATH)" ]; then \
+		cd $(LOGS_PATH) && tar -czf $(LOCAL_BACKUP_DIR)/logs_$$(date +%Y%m%d_%H%M%S).tar.gz .; \
+	else \
+		echo "Warning: Logs directory $(LOGS_PATH) not found."; \
+	fi
+	@echo "Logs backed up successfully to $(LOCAL_BACKUP_DIR)"
 
 restore-logs:
 	@if [ -z "$(FILE)" ]; then \
 		echo "Error: FILE parameter is required."; \
-		echo "Usage: make restore-logs FILE=path/to/backup.zip"; \
+		echo "Usage: make restore-logs FILE=path/to/backup.tar.gz"; \
 		exit 1; \
 	fi
-	@echo "Restoring logs to server..."
-	scp "$(FILE)" $(SERVER_USER)@$(SERVER_HOST):/tmp/logs_restore.zip
-	ssh $(SERVER_USER)@$(SERVER_HOST) "sudo unzip -o /tmp/logs_restore.zip -d $(LOGS_PATH) && rm /tmp/logs_restore.zip"
+	@echo "Restoring logs from $(FILE)..."
+	@mkdir -p $(LOGS_PATH)
+	@tar -xzf "$(FILE)" -C $(LOGS_PATH)
 	@echo "Logs restored successfully."
+
 
 # === MAINTENANCE ===
 clean-backups:
 	@echo "Cleaning local backups..."
-	rm -rf $(LOCAL_BACKUP_DIR)/*.zip
+	@rm -f $(LOCAL_BACKUP_DIR)/*.tar.gz $(LOCAL_BACKUP_DIR)/*.zip
 	@echo "All backups removed."
 
 init-backup:
-	@echo "Initializing local directories..."
-	mkdir -p $(LOCAL_BACKUP_DIR) $(LOCAL_UPLOADS_DIR) $(LOCAL_LOGS_DIR)
-	@echo "Done."
+	@echo "Initializing backup directory..."
+	@mkdir -p $(LOCAL_BACKUP_DIR)
+	@echo "Backup directory created at $(LOCAL_BACKUP_DIR)"
 
 rebuild:
-	@echo "Rebuilding and deploying project..."
-	make build
-	make deploy
+	@echo "Rebuilding and redeploying application..."
+	@$(MAKE) stop || true
+	@$(MAKE) build
+	@$(MAKE) start
+	@echo "Rebuild and deployment completed."


### PR DESCRIPTION
Fixes #16

## Changes Made

### Key Updates:
-  Removed SSH/remote server commands (SERVER_USER, SERVER_HOST, scp, ssh)
-  Updated for pm2-only process management (removed NGINX service management)
-  Changed backup/restore from zip+scp to local tar.gz operations
-  Added pm2 availability checks before operations
-  Simplified all commands to run directly on the server (not remotely)
-  Added `dev` command for development workflow
-  Improved help documentation and command structure
-  Used PM2_APP_NAME variable for consistency

## What Changed

**Before:** Makefile had SSH commands to deploy remotely, managed both NGINX and pm2, used zip+scp for backups

**After:** Makefile runs on server itself, manages only pm2 process, uses local tar for backups

## Commands Available

- `make dev` - Start development server
- `make build` - Build for production
- `make deploy` - Build and deploy with pm2
- `make start/stop/restart` - Manage pm2 application
- `make status` - Check pm2 status
- `make logs` - View pm2 logs
- `make backup-uploads/restore-uploads` - Backup/restore uploads
- `make backup-logs/restore-logs` - Backup/restore logs

All commands are designed to run on the production server as mentioned in PR #24 review.