### PR TITLE
Fix path vulnerability in admin.ts

### DIFF
--- a/src/app/api/gallery/admin/route.ts
+++ b/src/app/api/gallery/admin/route.ts
@@ -186,9 +186,37 @@ export async function PUT(request: NextRequest) {
             );
         }
 
-        const galleryDir = withStoragePath("gallery");
+        const isSafeFilename = (filename: string): boolean => {
+            if (!filename || typeof filename !== "string") return false;
+            if (filename === "." || filename === "..") return false;
+            if (filename.includes("/") || filename.includes("\\")) return false;
+            return path.basename(filename) === filename;
+        };
 
-        const oldPath = path.join(galleryDir, currentCategory, currentFilename);
+        if (!isSafeFilename(currentFilename) || (newFilename && !isSafeFilename(newFilename))) {
+            return NextResponse.json(
+                { error: "Invalid filename. Only simple file names are allowed." },
+                { status: 400 }
+            );
+        }
+
+        const galleryDir = withStoragePath("gallery");
+        const galleryRoot = path.resolve(galleryDir);
+
+        const currentCategoryDir = path.resolve(galleryRoot, currentCategory);
+        const targetCategory = newCategory || currentCategory;
+        const targetFilename = newFilename || currentFilename;
+        const targetCategoryDir = path.resolve(galleryRoot, targetCategory);
+
+        const oldPath = path.resolve(currentCategoryDir, currentFilename);
+        const newPath = path.resolve(targetCategoryDir, targetFilename);
+
+        if (
+            !oldPath.startsWith(currentCategoryDir + path.sep) ||
+            !newPath.startsWith(targetCategoryDir + path.sep)
+        ) {
+            return NextResponse.json({ error: "Invalid file path" }, { status: 400 });
+        }
 
         // Ensure the old file exists
         try {
@@ -197,12 +225,8 @@ export async function PUT(request: NextRequest) {
             return NextResponse.json({ error: "File not found" }, { status: 404 });
         }
 
-        const targetCategory = newCategory || currentCategory;
-        const targetFilename = newFilename || currentFilename;
-        const newPath = path.join(galleryDir, targetCategory, targetFilename);
-
         // Ensure target directory exists
-        await fs.mkdir(path.join(galleryDir, targetCategory), { recursive: true });
+        await fs.mkdir(targetCategoryDir, { recursive: true });
 
         // Check if target file already exists (unless it's the same file)
         if (oldPath !== newPath) {


### PR DESCRIPTION
Potential fix for [https://github.com/astronauticsclub-iiith/astronauticsclub-iiith.github.io/security/code-scanning/10](https://github.com/astronauticsclub-iiith/astronauticsclub-iiith.github.io/security/code-scanning/10)

To fix this safely without changing intended functionality, validate filename inputs as **simple filenames only** (no path separators, no traversal tokens), then enforce that resolved paths stay inside the expected category directory.

Best approach in this file:
1. Add a small helper to validate/sanitize filenames (reject empty, `.`/`..`, names containing `/` or `\`, and names that change when reduced to `path.basename`).
2. In `PUT`, validate `currentFilename` and `newFilename` (or resolved target filename when omitted).
3. Build category root dirs and file paths using `path.resolve`.
4. Enforce `resolvedPath.startsWith(resolvedCategoryDir + path.sep)` (or exact dir edge handling) for both old and new paths before any `fs` operation.
5. Keep current behavior (same category allowlist, same response structure), but return `400` on invalid filename/path.

This requires edits only in `src/app/api/gallery/admin/route.ts`:
- Add helper function near existing utility functions.
- Update path construction and add checks in `PUT` around lines 189–203 before `fs.access`, `mkdir`, `rename`, and `stat`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
