### PR TITLE
Fix Login bug

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,3 +7,7 @@ Before submitting a PR, ensure:
 - [ ] Tested on different screen sizes (responsive)
 - [ ] No console errors in browser
 - [ ] API endpoints work correctly
+
+**AI Tools Usage Disclosure**
+If AI tools were used, please mention
+Model/Tool Name: Describe how they were used.

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -32,8 +32,10 @@ function LoginContent() {
                     console.error("SignIn error:", result.error);
                     setError("Authentication failed. Please try again.");
                 } else {
-                    // Check if user has proper role
-                    const session = await getSession();
+                    // Fetch session with retries to avoid race condition.
+                    // After signIn(), the JWT cookie may not be fully
+                    // propagated when getSession() fires, causing it to
+                    // return stale data with no role.
                     interface ExtendedUser {
                         id?: string;
                         name?: string | null;
@@ -42,8 +44,18 @@ function LoginContent() {
                         role?: "admin" | "writer" | "none";
                     }
 
-                    const user = session?.user as ExtendedUser;
-                    const userRole = user?.role;
+                    let userRole: string | undefined;
+                    const maxRetries = 5;
+                    for (let attempt = 0; attempt < maxRetries; attempt++) {
+                        const session = await getSession();
+                        const user = session?.user as ExtendedUser;
+                        userRole = user?.role;
+
+                        if (userRole) break;
+
+                        // Wait before retrying (200ms, 400ms, 600ms, 800ms)
+                        await new Promise((resolve) => setTimeout(resolve, 200 * (attempt + 1)));
+                    }
 
                     console.log("Login redirect - User role:", userRole);
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 import { withBasePath } from "./components/common/HelperFunction";
 
 export default withAuth(
-    function prxoy(req) {
+    function proxy(req) {
         const token = req.nextauth.token;
         const isAdminRoute = req.nextUrl.pathname.startsWith(withBasePath(`/admin`));
         const isBlogAuthorRoute = req.nextUrl.pathname.startsWith(withBasePath(`/blog-editor`));


### PR DESCRIPTION
After `signIn()` completes, we were immediately calling `getSession()` without a timeout. However, `getSession()` from `next-auth/react` can return stale or cached session data because:
- The JWT session cookie may not be fully written or visible to the browser when the `getSession()` HTTP request fires
- The `next-auth/react` client has internal session caching that may not yet reflect the new login

When `getSession()` returns stale data, `user.role` is undefined, which doesn't match any role, so the code redirect to `/stay-away-snooper` despite successful CAS authentication. People in Whatsapp group had this issue so I guess this is the hidden race condition behind that. Added a timeout (5 retries of increasing timeperiod).