### PR TITLE
Fix Animation refresh bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3997,6 +3997,7 @@
             "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
                 "array-includes": "^3.1.9",

--- a/src/components/features/Landing/Hero.tsx
+++ b/src/components/features/Landing/Hero.tsx
@@ -39,7 +39,6 @@ const Hero = () => {
             if (!s) return;
 
             setWhimsyMode(!whimsyMode);
-            s.style.color = !whimsyMode ? "#d2042d" : "white";
         };
 
         s.addEventListener("click", handleClick);
@@ -74,8 +73,6 @@ const Hero = () => {
 
         // Create a sparkle element with random properties
         const createSparkle = () => {
-            if (whimsyMode) return; // Don't create sparkles in whimsy mode
-
             const sparkle = document.createElement("div");
 
             // Random size class
@@ -130,20 +127,7 @@ const Hero = () => {
             }
 
             // Create a new sparkle every 150-300ms
-            sparkleIntervalRef.current = setInterval(
-                () => {
-                    if (!whimsyMode) {
-                        createSparkle();
-                    } else {
-                        // If whimsy mode turned on, stop the sparkles
-                        if (sparkleIntervalRef.current) {
-                            clearInterval(sparkleIntervalRef.current);
-                            sparkleIntervalRef.current = null;
-                        }
-                    }
-                },
-                150 + Math.random() * 150
-            );
+            sparkleIntervalRef.current = setInterval(createSparkle, 150 + Math.random() * 150);
         };
 
         // Start creating sparkles

--- a/src/components/features/Landing/Hero.tsx
+++ b/src/components/features/Landing/Hero.tsx
@@ -164,32 +164,11 @@ const Hero = () => {
         };
     }, [isHydrated, isLoaded, whimsyMode]);
 
-    // Show simplified version during loading/hydration
-    if (!isLoaded || !isHydrated) {
-        return (
-            <section className="hero">
-                <section className="stars-container">
-                    <span></span>
-                    <span></span>
-                    <span></span>
-                    <span></span>
-                    <span></span>
-                </section>
-                <div className="hero-container">
-                    <div className="hero-content" style={{ height: "80%" }}>
-                        <h1 className="font-bold">
-                            <span className="nowrap">Astronautics</span>
-                            <span> Club</span>
-                        </h1>
-                    </div>
-                </div>
-            </section>
-        );
-    }
+    const isReady = isLoaded && isHydrated;
 
     return (
         <section className="hero">
-            {/* Sparkle container - positioned absolutely via JS */}
+            {/* Sparkle container - always in DOM to keep child order stable */}
             <div ref={sparkleContainerRef} className="s-sparkle-container"></div>
 
             <section className="stars-container">
@@ -210,7 +189,11 @@ const Hero = () => {
                     <h1 className="font-bold">
                         <span className="nowrap">
                             A
-                            <span ref={sRef} id="s-hover-effect" className="cursor-close">
+                            <span
+                                ref={sRef}
+                                id="s-hover-effect"
+                                className={isReady ? "cursor-close" : ""}
+                            >
                                 s
                             </span>
                             tronautics

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -114,14 +114,7 @@ const Navbar = () => {
             ? "text-white underline underline-offset-[5px]"
             : "text-white/50";
 
-    if (!isLoaded || !isHydrated) {
-        return (
-            <nav
-                className="fixed w-full z-50 transition-all duration-300 rounded-b-2xl select-none backdrop-blur-sm text-lg bg-black/95"
-                suppressHydrationWarning
-            ></nav>
-        );
-    }
+    const isReady = isLoaded && isHydrated;
 
     return (
         <nav

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -115,7 +115,7 @@ const Navbar = () => {
                     <Link href="/" className="flex items-center space-x-4 text-white">
                         <Image
                             src={
-                                whimsyMode
+                                isLoaded && whimsyMode
                                     ? withBasePath(`/icons/moon.gif`)
                                     : withBasePath(`/logo.png`)
                             }
@@ -128,7 +128,7 @@ const Navbar = () => {
                                     ? `${(delayCounter + 1) * 150}ms`
                                     : "200ms",
                             }}
-                            unoptimized={whimsyMode}
+                            unoptimized={isLoaded && whimsyMode}
                             priority
                         />
                         <div className="flex flex-col gap-0">
@@ -142,7 +142,7 @@ const Navbar = () => {
                             >
                                 Astronautics Club | IIITH
                             </span>
-                            {whimsyMode && (
+                            {isLoaded && whimsyMode && (
                                 <span
                                     className={`text-white/50 text-sm opacity-0 ${isAnimReady ? "animate-slide-in-from-top" : ""}`}
                                     style={{

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -12,6 +12,7 @@ const Navbar = () => {
     const [isScrolled, setIsScrolled] = useState(true);
     const [isFirstVisit, setIsFirstVisit] = useState(false);
     const [isHydrated, setIsHydrated] = useState(false);
+    const [isAnimReady, setIsAnimReady] = useState(false);
     const pathname = usePathname();
     const menuRef = useRef<HTMLDivElement>(null);
     const buttonRef = useRef<HTMLButtonElement>(null);
@@ -35,7 +36,7 @@ const Navbar = () => {
     useEffect(() => {
         if (!isHydrated || !isLoaded) return;
 
-        const checkFirstVisit = () => {
+        try {
             const lastVisit = localStorage.getItem("lastVisitTime");
             const currentTime = new Date().getTime();
 
@@ -46,9 +47,11 @@ const Navbar = () => {
             } else {
                 setIsFirstVisit(false);
             }
-        };
-
-        checkFirstVisit();
+        } catch (error) {
+            console.error("Error checking first visit:", error);
+        } finally {
+            setIsAnimReady(true);
+        }
     }, [isHydrated, isLoaded, whimsyMode]);
 
     // Close menu when route changes
@@ -119,33 +122,33 @@ const Navbar = () => {
                             alt="Logo"
                             width={80}
                             height={90}
-                            className="w-auto h-12 opacity-0 animate-fade-in z-50"
+                            className={`w-auto h-12 opacity-0 z-50 ${isAnimReady ? "animate-fade-in" : ""}`}
                             style={{
                                 animationDelay: isFirstVisit
                                     ? `${(delayCounter + 1) * 150}ms`
-                                    : "10ms",
+                                    : "200ms",
                             }}
                             unoptimized={whimsyMode}
                             priority
                         />
                         <div className="flex flex-col gap-0">
                             <span
-                                className="opacity-0 animate-slide-in-from-left z-20 font-bold"
+                                className={`opacity-0 z-20 font-bold ${isAnimReady ? "animate-slide-in-from-left" : ""}`}
                                 style={{
                                     animationDelay: isFirstVisit
                                         ? `${(delayCounter + 3) * 150}ms`
-                                        : "10ms",
+                                        : "200ms",
                                 }}
                             >
                                 Astronautics Club | IIITH
                             </span>
                             {whimsyMode && (
                                 <span
-                                    className="text-white/50 text-sm opacity-0 animate-slide-in-from-top"
+                                    className={`text-white/50 text-sm opacity-0 ${isAnimReady ? "animate-slide-in-from-top" : ""}`}
                                     style={{
                                         animationDelay: isFirstVisit
                                             ? `${(delayCounter + 4) * 150}ms`
-                                            : "10ms",
+                                            : "200ms",
                                     }}
                                 >
                                     Whimsy Mode
@@ -160,11 +163,11 @@ const Navbar = () => {
                             {navLinks.map((link, index) => (
                                 <li
                                     key={link.href}
-                                    className="opacity-0 animate-fade-in"
+                                    className={`opacity-0 ${isAnimReady ? "animate-fade-in" : ""}`}
                                     style={{
                                         animationDelay: isFirstVisit
                                             ? `${(delayCounter - index) * 150}ms`
-                                            : "10ms",
+                                            : "200ms",
                                     }}
                                 >
                                     <Link

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -7,25 +7,10 @@ import { usePathname } from "next/navigation";
 import { useWhimsy } from "@/context/WhimsyContext";
 import { withBasePath } from "../common/HelperFunction";
 
-// Helper function to get initial first visit state
-const getInitialFirstVisit = (): boolean => {
-    if (typeof window === "undefined") return false;
-    try {
-        const lastVisit = localStorage.getItem("lastVisitTime");
-        const currentTime = new Date().getTime();
-
-        // If no last visit or last visit was more than an hour ago
-        return !lastVisit || currentTime - parseInt(lastVisit) > 60 * 60 * 1000;
-    } catch (error) {
-        console.error("Error checking first visit:", error);
-        return false;
-    }
-};
-
 const Navbar = () => {
     const [isOpen, setIsOpen] = useState(false);
     const [isScrolled, setIsScrolled] = useState(true);
-    const [isFirstVisit, setIsFirstVisit] = useState<boolean>(getInitialFirstVisit);
+    const [isFirstVisit, setIsFirstVisit] = useState(false);
     const [isHydrated, setIsHydrated] = useState(false);
     const pathname = usePathname();
     const menuRef = useRef<HTMLDivElement>(null);
@@ -113,8 +98,6 @@ const Navbar = () => {
         pathname.startsWith(href) && (pathname === "/" || href !== "/")
             ? "text-white underline underline-offset-[5px]"
             : "text-white/50";
-
-    const isReady = isLoaded && isHydrated;
 
     return (
         <nav


### PR DESCRIPTION
When the homepage is loaded, for the shooting star animation there was a refresh effect when the navbar loaded. The cause was that the DOM swapped twice. Initially when both `isLoaded`, `isHydrated` were false, the number of span tags were 5 and the text was plain. The moment both hooks became true, there were 10 star spans, interactive elements. A new div was getting inserted which causes all the span elements to remount and the DOM to refresh (what I have observed for long time as well).

Changed it to a single DOM tree with 10 span elements, it's just that they are invisible by default. Also removed the empty nav placeholder that caused a full DOM rebuild when loaded.

Additionally removed `getInitialFirstVisit()` from `useState`, since it readz `localStorage` during initialization, returning false on the server but can be true on the client, which would have caused hydration mismatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering stability during page load and hydration in hero and navigation components.
  * Fixed accent color behavior on interactive elements.

* **Style**
  * Refined animation timings and delays for hero and navigation sections for improved visual feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/astronauticsclub-iiith/astronauticsclub-iiith.github.io/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->