### PR TITLE
Fix lint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,16 +1,13 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const compat = new FlatCompat({
-    baseDirectory: __dirname,
-});
+import nextConfig from "eslint-config-next";
+import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
+import nextTypescript from "eslint-config-next/typescript";
+import prettierConfig from "eslint-config-prettier";
 
 const eslintConfig = [
-    ...compat.extends("next/core-web-vitals", "next/typescript", "prettier"),
+    ...nextConfig,
+    ...nextCoreWebVitals,
+    ...nextTypescript,
+    prettierConfig,
 
     {
         rules: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,12 +34,11 @@
                 "@types/react": "19.2.14",
                 "@types/react-dom": "^19",
                 "eslint": "^9.39.4",
-                "eslint-config-next": "16.2.2",
+                "eslint-config-next": "^16.2.6",
                 "eslint-config-prettier": "^10.1.8",
                 "pm2": "^7.0.1",
                 "postcss": "^8",
                 "prettier": "^3.8.1",
-                "tailwindcss": "^4.2.2",
                 "typescript": "6.0.2"
             }
         },
@@ -87,6 +86,7 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -1204,9 +1204,9 @@
             "license": "MIT"
         },
         "node_modules/@next/eslint-plugin-next": {
-            "version": "16.2.2",
-            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.2.tgz",
-            "integrity": "sha512-IOPbWzDQ+76AtjZioaCjpIY72xNSDMnarZ2GMQ4wjNLvnJEJHqxQwGFhgnIWLV9klb4g/+amg88Tk5OXVpyLTw==",
+            "version": "16.2.6",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.6.tgz",
+            "integrity": "sha512-Z8l6o4JWKUl755x4R+wogD86KPeU+Ckw4K+SYG4kHeOJtRenDeK+OSbGcqZpDtbwn9DsJVdir2UxmwXuinUbUw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1917,6 +1917,7 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
             "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -2006,6 +2007,7 @@
             "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.58.0",
                 "@typescript-eslint/types": "8.58.0",
@@ -2472,6 +2474,7 @@
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2931,6 +2934,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.10.12",
                 "caniuse-lite": "^1.0.30001782",
@@ -3852,6 +3856,7 @@
             "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -3907,13 +3912,13 @@
             }
         },
         "node_modules/eslint-config-next": {
-            "version": "16.2.2",
-            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.2.tgz",
-            "integrity": "sha512-6VlvEhwoug2JpVgjZDhyXrJXUEuPY++TddzIpTaIRvlvlXXFgvQUtm3+Zr84IjFm0lXtJt73w19JA08tOaZVwg==",
+            "version": "16.2.6",
+            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.6.tgz",
+            "integrity": "sha512-z2ELYSkyrrJ6cuunTU8vhsT/RpouPkjaSah06nVW6Rg2Hpg0Vs8s497/e5s8G8qtdp4ccsiovz5P1rv+5VSW2Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@next/eslint-plugin-next": "16.2.2",
+                "@next/eslint-plugin-next": "16.2.6",
                 "eslint-import-resolver-node": "^0.3.6",
                 "eslint-import-resolver-typescript": "^3.5.2",
                 "eslint-plugin-import": "^2.32.0",
@@ -8290,6 +8295,7 @@
             "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
             "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/preact"
@@ -8433,6 +8439,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
             "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -8442,6 +8449,7 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
             "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -9093,6 +9101,7 @@
             "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ip-address": "^10.0.1",
                 "smart-buffer": "^4.2.0"
@@ -9484,6 +9493,7 @@
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -9695,6 +9705,7 @@
             "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -10236,6 +10247,7 @@
             "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@types/react": "19.2.14",
         "@types/react-dom": "^19",
         "eslint": "^9.39.4",
-        "eslint-config-next": "16.2.2",
+        "eslint-config-next": "^16.2.6",
         "eslint-config-prettier": "^10.1.8",
         "pm2": "^7.0.1",
         "postcss": "^8",


### PR DESCRIPTION
`eslint.config.mjs` was wrapping them through `FlatCompat` (which is a compatibility for legacy `.eslintrc-style` configs).  When `FlatCompat` tried to validate, serialize the react plugin object through `JSON.stringify`, it hit a circular reference.  Replaced the `FlatCompat` based config with direct flat config.